### PR TITLE
mocha tests

### DIFF
--- a/app.js
+++ b/app.js
@@ -31,8 +31,6 @@ var sdchLog = fs.createWriteStream(__dirname + '/logs/sdch.log', {flags: 'w'})
 // Middleware
 
 // setup the logger
-//app.use(function(req,res){ console.log(req.headers); })
-
 logger.token('hostname', function(req, res){ return url.parse(req.url).hostname })
 
 app.use(logger('common',
@@ -69,10 +67,10 @@ app.use(connectSdch.encode({
     // toEncode определяет какой словарь будет использован для шифрования ответа
     toEncode: function(req, availDicts) {
         // Use only first dictionary
-        //if (availDicts.length > 0 &&
-          //  availDicts[0] === dicts[0].clientHash)
+        if (availDicts.length > 0 &&
+            availDicts[0] === dicts[0].clientHash)
             return dicts[0]
-       // return null;
+        return null;
     }
 }, { /* some vcdiff options */ }));
 
@@ -97,7 +95,6 @@ app.get('/*', function proxy(req, res, next) { // get по любому url
             for (var k in resp.headers) {
                 res.setHeader(k, resp.headers[k]);
             }
-            //res.setHeader("content-encoding", 'sdch')
             p.pipe(res);
         }).end();
 });

--- a/config.js
+++ b/config.js
@@ -1,0 +1,15 @@
+// proxy settings
+exports.PROXY = {
+    HOST: "kotik.cc",
+    PORT: 3002
+}
+// test-server settings
+exports.SERVER = {
+    HOST: "kotik.cc",
+    PORT: 7272
+}
+// dictionary settings
+exports.DICTS = {
+    PATH: '/dictionaries/search_dict',
+    FILE: 'model.fzm'
+}

--- a/package.json
+++ b/package.json
@@ -1,14 +1,17 @@
 {
   "name": "node-sdch-proxy",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "private": true,
   "scripts": {
-    "start": "node ./app.js"
+    "start": "node ./app.js",
+    "test": "mocha"
   },
   "dependencies": {
     "express": "~4.9.0",
     "connect-sdch": "~0.0.2",
     "morgan": "~1.3.0",
+    "mocha": "~2.0.1",
+    "chai": "~1.9.2",
     "debug": "~2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,8 +10,11 @@
     "express": "~4.9.0",
     "connect-sdch": "~0.0.2",
     "morgan": "~1.3.0",
-    "mocha": "~2.0.1",
-    "chai": "~1.9.2",
     "debug": "~2.0.0"
+  },
+  "devDependencies": {
+    "chai": "~1.9.2",
+    "mocha": "~2.0.1"
+
   }
 }

--- a/test-server.js
+++ b/test-server.js
@@ -1,0 +1,48 @@
+var http = require('http');
+var url = require('url');
+var config = require('./config.js');
+
+var server = http.createServer(function(req,resp){
+    //что за запрос вообще к нам пришел?
+    //console.log(req.method, req.url);
+
+    var parsed_url = url.parse(req.url, true);
+    //console.log(req.headers)
+    if (parsed_url.pathname == '/test1')
+    {
+        resp.setHeader('content-type', 'text/plain');
+        resp.setHeader('content-length', 6);
+        resp.end("Hello!");
+    }
+    else if (parsed_url.pathname == '/test2')
+    {
+        resp.setHeader('content-type', 'text/plain');
+        resp.setHeader('Cache-Control', 'private');
+        resp.setHeader('content-length', 6);
+        resp.end("Hello!");
+    }
+    else if (parsed_url.pathname == '/search&q=brussel')
+    {
+        resp.setHeader('content-type', 'text/plain');
+        resp.setHeader('Cache-Control', 'private');
+        resp.setHeader('content-length', 36);
+        resp.end("Hello!Hello!Hello!Hello!Hello!Hello!");
+    }
+    else
+    {
+        resp.statusCode = 404;
+        resp.end("Sorry, Page Not found!");
+    }
+
+})
+
+function run() {
+    server.listen(config.SERVER.PORT, config.SERVER.HOST);
+    console.log("test-server listening on port " + config.SERVER.PORT);
+}
+
+if (module.parent) {
+    exports.run = run
+} else {
+    run()
+}

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,193 @@
+var assert = require('chai').assert;
+var http = require('http');
+var sdch = require('sdch');
+var config = require('../config');
+var proxy = require('../app');
+var test_server = require('../test-server');
+
+var resp;
+
+describe('Node-sdch-proxy tests:', function() {
+
+    before(function() {
+        assert.doesNotThrow(function () {
+            proxy.run()
+            test_server.run()
+        })
+    })
+
+    describe('Without Accept-Encoding: sdch', function () {
+
+        before(function (done) {
+            http.get({
+                host: config.PROXY.HOST,
+                port: config.PROXY.PORT,
+                path: "http://" + config.SERVER.HOST + ":" + config.SERVER.PORT + "/test1",
+                headers: {
+                    Host: config.SERVER.HOST
+                }
+            }, function (res) {
+                resp = res;
+                done()
+            })
+        });
+
+        describe('proxy response:', function () {
+            it('have statusCode == 200 OK', function () {
+                assert.equal(200, resp.statusCode);
+            })
+
+            it("have via == 'My-precious-proxy'", function () {
+                assert.equal('My-precious-proxy', resp.headers['via'])
+            })
+
+            it("have content-type == 'text/plain'", function () {
+                assert.equal('text/plain', resp.headers['content-type']);
+            })
+
+            it("have content-length value", function () {
+                assert.isDefined(resp.headers['content-length']);
+            })
+
+            it("Get-Dictionary: Empty", function () {
+                assert.isUndefined(resp.headers['Get-Dictionary'])
+            })
+
+            it("Content-Encoding: Not contain sdch", function () {
+                assert.notInclude(resp.headers['Content-Encoding'], 'sdch')
+            })
+        })
+    })
+    describe('Initial Interaction, User Agent has No Dictionaries', function () {
+        before(function (done) {
+            http.get({
+                host: config.PROXY.HOST,
+                port: config.PROXY.PORT,
+                path: "http://" + config.SERVER.HOST + ":" + config.SERVER.PORT + "/test2",
+                headers: {
+                    Host: config.SERVER.HOST,
+                    'Accept-Encoding': 'sdch, gzip'
+                }
+            }, function (res) {
+                resp = res;
+                done()
+            })
+        });
+
+        describe('proxy response:', function () {
+            it('have statusCode == 200 OK', function () {
+                assert.equal(200, resp.statusCode);
+            })
+
+            it("have via == 'My-precious-proxy'", function () {
+                assert.equal('My-precious-proxy', resp.headers['via'])
+            })
+
+            it("have content-type == 'text/plain'", function () {
+                assert.equal('text/plain', resp.headers['content-type']);
+            })
+
+            it("have content-length value", function () {
+                assert.isDefined(resp.headers['content-length']);
+            })
+
+            it('Get-Dictionary: Not Empty', function () {
+                assert.isNotNull(resp.headers['Get-Dictionary'])
+            })
+
+            it("Content-Encoding: Not contain 'sdch'", function () {
+                assert.notInclude(resp.headers['Content-Encoding'], 'sdch')
+            })
+        })
+    })
+
+    var dict = '/dictionaries/search_dict'
+
+    describe('User Agent Requests the Dictionary', function () {
+        before(function (done) {
+            http.get({
+                host: config.PROXY.HOST,
+                port: config.PROXY.PORT,
+                path: "http://" + config.SERVER.HOST + ":" + config.SERVER.PORT + dict,
+                headers: {
+                    Host: config.SERVER.HOST,
+                    'Accept-Encoding': 'sdch, gzip'
+                }
+            }, function (res) {
+                resp = res;
+                resp.body = ''
+                res.on('data', function (d) {
+                    resp.body += d;
+                });
+                res.on('end', function () {
+                    done()
+                })
+            })
+        });
+
+        describe('proxy response:', function () {
+            it('have statusCode == 200 OK', function () {
+                assert.equal(200, resp.statusCode);
+            })
+
+            it("have Content-type == 'application/x-sdch-dictionary'", function () {
+                assert.equal('application/x-sdch-dictionary', resp.headers['content-type']);
+            })
+
+            it("Content-Encoding: Not contain 'sdch'", function () {
+                assert.notInclude(resp.headers['Content-Encoding'], 'sdch')
+            })
+
+            it('valid dictionary headers', function () {
+                var url = "http://" + config.SERVER.HOST + ":" + config.SERVER.PORT + dict
+                assert.doesNotThrow(function () {
+                    var opts = sdch.createDictionaryOptions(url, resp.body)
+                    var dict = sdch.clientUtils.createDictionaryFromOptions(opts)
+                })
+
+            })
+        })
+    })
+
+    describe('User Requests Page AND User Agent Has Already Downloaded the Dictionary', function () {
+        before(function (done) {
+            http.get({
+                host: config.PROXY.HOST,
+                port: config.PROXY.PORT,
+                path: "http://" + config.SERVER.HOST + ":" + config.SERVER.PORT + '/search&q=brussel',
+                headers: {
+                    Host: config.SERVER.HOST,
+                    'Accept-Encoding': 'sdch',
+                    'Avail-Dictionary': 'TWFuIGlz'
+                }
+            }, function (res) {
+                resp = res;
+                done()
+            })
+        });
+
+        describe('proxy response:', function () {
+            it('have statusCode == 200 OK', function () {
+                assert.equal(200, resp.statusCode);
+            })
+
+            it("have via == 'My-precious-proxy'", function () {
+                assert.equal('My-precious-proxy', resp.headers['via'])
+            })
+            
+            it("have content-type == 'text/plain'", function () {
+                assert.equal('text/plain', resp.headers['content-type']);
+            })
+
+            it("Content-Encoding: contain 'sdch'", function () {
+                //console.log(resp)
+                assert.include(resp.headers['content-encoding'], 'sdch')
+            })
+
+            it("Get-Dictionary: Not contain already downloaded dictionary", function () {
+                assert.notInclude(resp.headers['Get-Dictionary'], dict)
+            });
+        })
+    })
+})
+


### PR DESCRIPTION
Всего 4 теста:
Test 0: Without Accept-Encoding: sdch
Test 1: Initial Interaction, User Agent has No Dictionaries
Test 2: User Agent Requests the Dictionary
Test 3: User Requests Page AND User Agent Has Already Downloaded the Dictionary

Последний фейлится на
      => Content-Encoding: contain 'sdch'
✓ valid dictionary headers порошел после замены 127.0.0.1 на 'kotik.cc'
